### PR TITLE
docs: new canonical URL inveniosoftware.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
-======================
- invenio-software.org
-======================
+=====================
+ inveniosoftware.org
+=====================
 
-This repository contains sources of the http://invenio-software.org
+This repository contains sources of the http://inveniosoftware.org
 web site.  Please go there to see the web site in action.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   Github: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/conf/inveniosoftware.conf
+++ b/conf/inveniosoftware.conf
@@ -20,7 +20,7 @@ upstream inveniokwalitee {
 
 server {
     listen 80;
-    server_name demo.invenio-software.org demo.inveniosoftware.org;
+    server_name demo.inveniosoftware.org demo.invenio-software.org;
     location / {
         proxy_pass http://inveniodemo;
     }
@@ -28,7 +28,7 @@ server {
 
 server {
     listen 80;
-    server_name kwalitee.invenio-software.org kwalitee.inveniosoftware.org;
+    server_name kwalitee.inveniosoftware.org kwalitee.invenio-software.org;
     location / {
         proxy_pass http://inveniokwalitee;
     }


### PR DESCRIPTION
* Switches from the old canonical URL (`invenio-software.org`) to the
  new canonical URL (`inveniosoftware.org`).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>