### PR TITLE
 nginx: no caching for `/showcase` endpoint

### DIFF
--- a/base/templates/index.html
+++ b/base/templates/index.html
@@ -113,10 +113,11 @@
                                 <img src="/static/img/logo-cern-white.svg">
                             </div>
                             <div class="carousel-item-text">
-                                <p>Invenio has been originally developed at <a href="https://home.cern">CERN</a>
-                                   to run the <a href="https://cds.cern.ch">CERN document server</a>,
+                                <p>Invenio was born at <a href="https://home.cern">CERN</a> as
+                                   a digital library software solution to run the
+                                   <a href="https://cds.cern.ch">CERN document server</a>,
                                    managing over 1,000,000 bibliographic records
-                                   in high-energy physics since 2002, covering
+                                   in high-energy physics since 2002. Covering
                                    articles, books, journals, photos, videos,
                                    and more.</p>
                             </div>
@@ -130,12 +131,21 @@
                                 <img src="/static/img/icon-collaboration.svg">
                             </div>
                             <div class="carousel-item-text">
-                                <p>Invenio is nowadays co-developed by an
-                                   international collaboration comprising
-                                   institutes such as AUTH, CfA, CERN, DESY,
-                                   EPFL, FNAL, FZJ, GSI, RERO, SLAC, UAB and is
-                                   being used by many scientific institutes and
-                                   library networks worldwide.</p>
+                                <p>Over the years, Invenio has been co-developed by an
+                                   international collaboration with contributions from
+                                   institutes such as
+                                   <a href="http://www.auth.gr/en">AUTH</a>,
+                                   <a href="https://www.cfa.harvard.edu/">CFA</a>,
+                                   <a href="http://home.cern/">CERN</a>,
+                                   <a href="http://www.desy.de/">DESY</a>,
+                                   <a href="http://epfl.ch/">EPFL</a>,
+                                   <a href="http://www.fz-juelich.de/">FZJ</a>,
+                                   <a href="http://gsi.de/">GSI</a>,
+                                   <a href="https://www.rero.ch/">RERO</a>,
+                                   <a href="https://slac.stanford.edu/">SLAC</a>,
+                                   <a href="http://uab.cat/">UAB</a> and more.
+                                   Invenio is being used by many scientific
+                                   institutes and library networks worldwide.</p>
                             </div>
                         </div>
                     </div>
@@ -147,7 +157,7 @@
                               <img src="/static/img/icon-open-source.svg">
                           </div>
                           <div class="carousel-item-text">
-                              <p>Invenio is a free software suite that consists
+                              <p>Nowadays, Invenio software suite consists
                                  of more than a hundred independent packages
                                  that collaborate via strong REST API. The
                                  flexibility and performance of Invenio make it

--- a/nginx/inveniosoftware.conf
+++ b/nginx/inveniosoftware.conf
@@ -39,6 +39,9 @@ server {
     location /download/ {
         root /usr/share/nginx/html;
     }
+    location /showcase {
+        proxy_pass http://web:5000;
+    }
     location / {
         proxy_pass http://web:5000;
         proxy_cache all;


### PR DESCRIPTION
* Takes `/showcase` endpoint out of the nginx reverse proxy caching
      process, because this page needs server-side mobile browser
      detection. (closes #23)
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>