### PR TITLE
sites: updated inspire url

### DIFF
--- a/base/sites/inspire.json
+++ b/base/sites/inspire.json
@@ -1,7 +1,7 @@
 {
   "name": "INSPIRE",
   "description": "Run by a collaboration of CERN, DESY, Fermilab, IHEP, and SLAC, and interacts closely with HEP publishers, arXiv.org, NASA-ADS, PDG, HEPDATA and others.",
-  "url": "http://inspire.org",
+  "url": "http://inspirehep.net",
   "screenshot_filename": "inspire.png",
   "types": ["institutional-repository"],
   "featured": true


### PR DESCRIPTION
Signed-off-by: Javier Martin Montull <javier.martin.montull@cern.ch>