### PR TITLE
nginx: removal of DEMO and KWALITEE

### DIFF
--- a/nginx/inveniosoftware.conf
+++ b/nginx/inveniosoftware.conf
@@ -10,30 +10,6 @@ proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-upstream inveniodemo {
-   server 128.142.145.121:8080;
-}
-
-upstream inveniokwalitee {
-   server 188.184.185.199:80;
-}
-
-server {
-    listen 80;
-    server_name demo.inveniosoftware.org demo.invenio-software.org;
-    location / {
-        proxy_pass http://inveniodemo;
-    }
-}
-
-server {
-    listen 80;
-    server_name kwalitee.inveniosoftware.org kwalitee.invenio-software.org;
-    location / {
-        proxy_pass http://inveniokwalitee;
-    }
-}
-
 server {
     listen 80 default_server;
     location /download/ {


### PR DESCRIPTION
* Removes Nginx configuration for DEMO (that is now hosted on a separate box)
  and KWALITEE (that is no longer used in the server mode).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>