### PR TITLE
templates: simpler git clone instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,5 @@ install:
   - docker-compose up -d
 
 script:
+  - sleep 5
   - curl -s http://127.0.0.1/ | grep -q Invenio

--- a/base/templates/pages/gettingstarted.html
+++ b/base/templates/pages/gettingstarted.html
@@ -11,7 +11,7 @@
         <div class="col-md-6">
           <h6>Invenio 1.2</h6>
           <p>Install latest stable release in a virtual machine using <a href="https://www.vagrantup.com/">vagrant</a>:</p>
-          <p class="code">$ <span class="command">git</span> clone git@github.com:inveniosoftware/invenio -b maint-1.2
+          <p class="code">$ <span class="command">git</span> clone https://github.com/inveniosoftware/invenio -b maint-1.2
             $ <span class="command">cd</span> invenio
             $ <span class="command">vagrant</span> up && <span class="command">vagrant</span> ssh web
               web> <span class="command">source .inveniorc</span>
@@ -23,7 +23,7 @@
         <div class="col-md-6">
           <h6>Invenio 3.0</h6>
           <p>Install latest developer preview using <a href="http://www.docker.com/">docker</a>:</p>
-          <p class="code">$ <span class="command">git</span> clone git@github.com:inveniosoftware/invenio
+          <p class="code">$ <span class="command">git</span> clone https://github.com/inveniosoftware/invenio
             $ <span class="command">cd</span> invenio
             $ <span class="command">docker-compose</span> build
             $ <span class="command">docker-compose</span> up -d

--- a/base/templates/pages/showcase_add.html
+++ b/base/templates/pages/showcase_add.html
@@ -44,7 +44,7 @@
             <div class="col-md-9 col-md-offset-1">
                 <h6>Fork our source code</h6>
                 <p>Fork <a href="https://github.com/inveniosoftware/inveniosoftware.org">inveniosoftware.org</a> source code repository using your GitHub account (e.g. <code>johndoe</code>) and create a new local branch (e.g. <code>johndoelibrary</code>):</p>
-              <p class="code">$ <span class="command">git</span> clone git@github.com:johndoe/inveniosoftware.org
+              <p class="code">$ <span class="command">git</span> clone https://github.com/johndoe/inveniosoftware.org
                 $ <span class="command">cd</span> inveniosoftware.org
                 $ <span class="command">git</span> checkout -b johndoelibrary</p>
             </div>

--- a/nginx/inveniosoftware.conf
+++ b/nginx/inveniosoftware.conf
@@ -10,30 +10,6 @@ proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-upstream inveniodemo {
-   server 128.142.145.121:8080;
-}
-
-upstream inveniokwalitee {
-   server 188.184.185.199:80;
-}
-
-server {
-    listen 80;
-    server_name demo.inveniosoftware.org demo.invenio-software.org;
-    location / {
-        proxy_pass http://inveniodemo;
-    }
-}
-
-server {
-    listen 80;
-    server_name kwalitee.inveniosoftware.org kwalitee.invenio-software.org;
-    location / {
-        proxy_pass http://inveniokwalitee;
-    }
-}
-
 server {
     listen 80 default_server;
     location /download/ {


### PR DESCRIPTION
* Changes `git clone` instructions to use HTTPS instead of the Git protocol,
  so that new users can clone the repository "anonymously" and don't have
  to set up authentication tokens.
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>