### PR TITLE
404: use absolute URLs

### DIFF
--- a/inveniosoftware.org.lektorproject
+++ b/inveniosoftware.org.lektorproject
@@ -1,5 +1,6 @@
 [project]
 name = inveniosoftware.org
+url_style = absolute
 
 [servers.ghpages]
 target = ghpages+https://inveniosoftware/inveniosoftware.org

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,9 +1,9 @@
 {% extends 'page.html' %}
 
-{% block page_title %}Getting started with Invenio{% endblock %}
+{% block page_title %}Error{% endblock %}
 {% block body %}
     <div class="container section-content-dark-bg error-page">
-      <h3 class="error-page-title">Oops! The requested resource does not exist. You may want to go to the <a href="{{'/'|url}}">home page</a>.</h3>
+      <h3 class="error-page-title">Oops! The requested resource does not exist. Please see the <a href="{{'/'|url}}">home page</a>.</h3>
       {% include 'footer_contact.html' %}
     </div>
   </section>


### PR DESCRIPTION
* Configures Lektor to use absolute URLs in order to produce nicely-styled 404
  pages for any arbitrarily nested missing resources. Amends some 404 page
  text. (closes #71)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>