### PR TITLE
gettingstarted: data model in parent directory

### DIFF
--- a/templates/gettingstarted.html
+++ b/templates/gettingstarted.html
@@ -34,8 +34,7 @@
             <div class="command-line">
                 <div class="line comment"># select instance</div>
                 <div class="line"><span class="prompt">$</span>workon my-site</div>
-                <div class="line"><span class="prompt">$</span>cd my-site</div>
-                <div class="line comment"># scaffold data model</div>
+                <div class="line comment"># scaffold data model in the same parent directory</div>
                 <div class="line"><span class="prompt">$</span>cookiecutter \</div>
                 <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-datamodel -c v3.0</div></div>
                 <div class="line comment"># install and register data model</div>


### PR DESCRIPTION
In the full [Quickstart](https://invenio.readthedocs.io/en/latest/quickstart/quickstart.html#customize) the data model and the instance share the same parent directory, I guess this is the way we wanted it to be done.