### PR TITLE
gettingstarted: use pipenv instead of pip

### DIFF
--- a/templates/gettingstarted.html
+++ b/templates/gettingstarted.html
@@ -10,7 +10,7 @@
       <div class="row">
          <div class="col-md-8 col-md-offset-2">
             <p>
-              Invenio 3.0 is a digital repository framework that enables you to
+              Invenio 3.1 is a digital repository framework that enables you to
               easily bootstap, customise and run your own digital repository
               instances.
             </p>
@@ -21,7 +21,7 @@
                 <div class="line comment"># create my-site instance</div>
                 <div class="line"><span class="prompt">$</span>mkvirtualenv my-site</div>
                 <div class="line"><span class="prompt">$</span>cookiecutter \</div>
-                <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-instance -c v3.0</div></div>
+                <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-instance -c v3.1</div></div>
                 <div class="line"><span class="prompt">$</span>cd my-site</div>
                 <div class="line comment"># start services (db, es, mq, etc)</div>
                 <div class="line"><span class="prompt">$</span>docker-compose up -d</div>
@@ -36,10 +36,10 @@
                 <div class="line"><span class="prompt">$</span>workon my-site</div>
                 <div class="line comment"># scaffold data model in the same parent directory</div>
                 <div class="line"><span class="prompt">$</span>cookiecutter \</div>
-                <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-datamodel -c v3.0</div></div>
+                <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-datamodel -c v3.1</div></div>
                 <div class="line comment"># install and register data model</div>
                 <div class="line"><span class="prompt">$</span>cd my-datamodel</div>
-                <div class="line"><span class="prompt">$</span>pip install -e .</div>
+                <div class="line"><span class="prompt">$</span>pipenv install -e .</div>
             </div>
             <p>
                We can now run the newly created instance:

--- a/templates/index.html
+++ b/templates/index.html
@@ -138,7 +138,7 @@
             <div class="line comment"># scaffold my-site instance</div>
             <div class="line"><span class="prompt">$</span>mkvirtualenv my-site</div>
             <div class="line"><span class="prompt">$</span>cookiecutter \</div>
-            <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-instance -c v3.0</div></div>
+            <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-instance -c v3.1</div></div>
             <div class="line"><span class="prompt">$</span>cd my-site</div>
             <div class="line comment"># start services (db, es, mq, etc)</div>
             <div class="line"><span class="prompt">$</span>docker-compose up -d</div>
@@ -156,10 +156,10 @@
             <div class="line"><span class="prompt">$</span>workon my-site</div>
             <div class="line comment"># scaffold data model</div>
             <div class="line"><span class="prompt">$</span>cookiecutter \</div>
-            <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-datamodel -c v3.0</div></div>
+            <div class="line"><div class="tab">gh:inveniosoftware/cookiecutter-invenio-datamodel -c v3.1</div></div>
             <div class="line comment"># install and register data model</div>
             <div class="line"><span class="prompt">$</span>cd my-datamodel</div>
-            <div class="line"><span class="prompt">$</span>pip install -e .</div>
+            <div class="line"><span class="prompt">$</span>pipenv install -e .</div>
           </div>
         </div>
         <div class="col-md-4">


### PR DESCRIPTION
Fix Documentation to use pipenv instead of pip.

Related to https://github.com/inveniosoftware/cookiecutter-invenio-instance/issues/83