### PR TITLE
rdm: update roadmap up to January 2020

### DIFF
--- a/templates/products/rdm/roadmap.html
+++ b/templates/products/rdm/roadmap.html
@@ -76,19 +76,18 @@
           <p>Nov</p>
         </div>
         <div class="roadmap-row-content">
-          <h3>Alpha: Advanced Customizations</h3>
+          <h3>Alpha: Cross-platform CLI and "cool" recids</h3>
           <h4>Milestones</h4>
           <ul>
-            <li>Review of alpha 1</li>
-            <li>Demo site in OpenShift with demo data.</li>
+            <li>Review of alpha 1 <i class="fa fa-check text-success"></i></li>
           </ul>
           <h4>Release (alpha 2)</h4>
           <ul>
-            <li>Change layout to match institutional style (CSS and templates)</li>
-            <li>Customize data model (resource type, custom fields, feature flags)</li>
-            <li>Application profiles and plugin architecture</li>
+            <li>Make invenio-cli cross-platform via a 100% port to Python</li>
+            <li>Configuration experience (e.g., permission policy)</li>
+            <li>Use "cool" recids for records (e.g., "skyer-9sg46")</li>
           </ul>
-          <small><a href="https://github.com/orgs/inveniosoftware/projects/28">Project board</a> | <a href="https://github.com/inveniosoftware/rfcs/pulls">Upcoming RFCs</a> | M5</small>
+          <small><a href="https://github.com/orgs/inveniosoftware/projects/28">Project board</a> | <a href="https://github.com/inveniosoftware/rfcs/pulls">RFCs</a> | M5</small>
         </div>
       </div>
       <div class="roadmap-row">
@@ -96,18 +95,19 @@
           <p>Dec</p>
         </div>
         <div class="roadmap-row-content">
-          <h3>Alpha: Deployment</h3>
+          <h3>Alpha: Default UI and Invenio 3.2 Files</h3>
           <h4>Milestones</h4>
           <ul>
-            <li>Review of alpha 2</li>
-            <li>Online user documentation</li>
-            <li>Zenodo/Digital Hub migration test</li>
+            <li>Review of alpha 2 <i class="fa fa-check text-success"></i></li>
+            <li>Presentation and live demo at CNI <i class="fa fa-check text-success"></i></li>
           </ul>
           <h4>Release (alpha 3)</h4>
           <ul>
-            <li>OpenShift deployment templates</li>
+            <li>Initial default front, search and record pages UI</li>
+            <li>Integrate new Invenio 3.2 release</li>
+            <li>Upload a file via the API (see the listed file on UI)</li>
           </ul>
-          <small>M6</small>
+          <small><a href="https://github.com/orgs/inveniosoftware/projects/29">Project board</a> | <a href="https://github.com/inveniosoftware/rfcs/pulls">Upcoming RFCs</a> | M6</small>
         </div>
       </div>
     </div>
@@ -130,7 +130,7 @@
           <ul>
             <li>TBD</li>
           </ul>
-          <small>M7</small>
+          <small><a href="https://github.com/orgs/inveniosoftware/projects/30">Project board</a> | <a href="https://github.com/inveniosoftware/rfcs/pulls">Upcoming RFCs</a> | M7</small>
         </div>
       </div>
       <div class="roadmap-row">


### PR DESCRIPTION
I made updates to the roadmap to reflect our changed tasks/milestones.

It would be nice to have a visual cue as to where we currently are and update it every month.

I am not 100% clear on the difference between `Milestones` and `Release` section, but I tried to follow suit based on other examples.