### PR TITLE
Remove "Deploy" and "Extend" links in the Documentation page

### DIFF
--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -70,11 +70,7 @@
                 </div>
               </div>
               <div class="list-group">
-                <a class="list-group-item" href="https://inveniordm.docs.cern.ch/deployment/">
-                  <i class="fa fa-fw fa-rocket"></i>
-                  Deploy
-                </a>
-                <a class="list-group-item" href="https://inveniordm.docs.cern.ch/extensions/">
+                <a class="list-group-item" href="https://inveniordm.docs.cern.ch/develop/topics/extensions/">
                   <i class="fa fa-fw fa-cubes"></i>
                   Extend
                 </a>


### PR DESCRIPTION
The documentation page on https://inveniosoftware.org/documentation/ currently has 2 broken links: "Extend" and "Deploy". I'm not sure the Extension page/feature is still maintained (I could find an archived version [here](https://web.archive.org/web/20201130070936/https://inveniordm.docs.cern.ch/extensions/)) and the Deployment instructions should probably point to a guide for the Helm Charts (which we don't have at the moment) so I suggest removing both for the time being