### PR TITLE
Clean up of the showcased "Examples" 

### DIFF
--- a/databags/sites.json
+++ b/databags/sites.json
@@ -155,14 +155,6 @@
       "types": ["library", "institutional-repository"]
     },
     {
-      "name": "University of Applied Sciences of Freiburg (Western Switzerland)",
-      "country": "CH",
-      "description": "University of Applied Sciences of Freiburg (Western Switzerland)",
-      "url": "https://multidoc.eia-fr.ch",
-      "screenshot_filename": "heiaf.png",
-      "types": ["institutional-repository", "library"]
-    },
-    {
       "name": "HEPData",
       "description": "The Durham High Energy Physics Database (HEPData) has been built up over the past four decades as a unique open-access repository for scattering data from experimental particle physics. It currently comprises the data points from plots and tables related to several thousand publications including those from the Large Hadron Collider (LHC).",
       "url": "http://hepdata.net",
@@ -215,14 +207,6 @@
       "url": "http://ikee.lib.auth.gr/",
       "screenshot_filename": "ikee.png",
       "types": ["library", "institutional-repository"]
-    },
-    {
-      "name": "ILC Document Server",
-      "country": "CH",
-      "description": "The document server of the International Linear Collider. Planning and designing the proposed electron-positron collider will require global participation and global organization. ILCDoc serves as a central repository for project documents and information shared among the hundreds of collaborators, scientists and engineers, at university and laboratories around the world.",
-      "url": "http://ilcdoc.linearcollider.org/",
-      "screenshot_filename": "ilcdoc.png",
-      "types": ["research-data", "institutional-repository", "library"]
     },
     {
       "name": "INSPIRE",


### PR DESCRIPTION
I've removed some websites from the Examples of Invenio instances over https://inveniosoftware.org/showcase/:

- ILCDoc is now offline. The domain is now apparently an alias for just CDS
- https://multidoc.eia-fr.ch/ just points to a "AGF M365 oAuth2 test page"

I'd like to do also do some further cleanup, as the following websites seems also to be offline to me:

- [ ] sysdoc.com.dtu.dk (DTU Fotonik Optical Communication Document Server)
- [ ] https://olin.tind.io/ 
- [ ] https://mpe.tind.io/
- [ ] http://library.kpoly.edu.gh/
- [ ] http://cdsinvenio.iheid.ch/
- [ ] https://ekp-invenio.physik.uni-karlsruhe.de/


Assets should also be removed (screenshots)