### PR TITLE
fix: button links focus text visibility

### DIFF
--- a/assets/static/css/style.css
+++ b/assets/static/css/style.css
@@ -795,6 +795,7 @@ footer nav li.title {
   font-weight: 200;
 }
 .goto-button a:hover,
+.goto-button a:focus,
 .goto-button a:active {
   color: white;
 }
@@ -805,6 +806,7 @@ footer nav li.title {
   display: inline-flex;
 }
 .goto-icon-button-a:hover i,
+.goto-icon-button-a:focus i,
 .goto-icon-button-a:active i {
   color: white !important;
   background-color: #0377cd;


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Fixes #172 

When the blue button-like link elements are focused, the rule `.section-content-light-bg a:focus` is setting the text to the same blue (`#0377cd`) as the background color (rule `.goto-button a`), making the text unreadable.

Adding the `.goto-button a:focus` to the existing rule already setting the text to white on hover and active fixes this problem.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
