### PR TITLE
fix: broken links in v12 release blog post

### DIFF
--- a/content/blog/2024-08-20-invenio-rdm-12/contents.lr
+++ b/content/blog/2024-08-20-invenio-rdm-12/contents.lr
@@ -10,7 +10,7 @@ body:
 
 ![](invenio-rdm-v12.0-screenshot.png)
 
-We are happy to announce the release of InvenioRDM [v12.0](https://inveniordm.docs.cern.ch/releases/versions/version-v12.0.0/)! Released on August 1, 2024, it is the first InvenioRDM release since [v11.0](https://inveniordm.docs.cern.ch/releases/versions/version-v11.0.0/) was released on January 23, 2023, and it includes not only many bug fixes and small improvements but also several major new features listed below.
+We are happy to announce the release of InvenioRDM [v12.0](https://inveniordm.docs.cern.ch/releases/v12/version-v12.0.0/)! Released on August 1, 2024, it is the first InvenioRDM release since [v11.0](https://inveniordm.docs.cern.ch/releases/v11/version-v11.0.0/) was released on January 23, 2023, and it includes not only many bug fixes and small improvements but also several major new features listed below.
 
 Since the v11.0 release several [InvenioRDM partners](https://inveniosoftware.org/products/rdm/) have launched InvenioRDM instances in production, including [Zenodo, which migrated to InvenioRDM in October 2023](https://blog.zenodo.org/2023/10/13/2023-10-13-zenodo-rdm/). A number of these partners have migrated already to InvenioRDM v12.0 or plan to do so in the coming months.
 
@@ -22,7 +22,7 @@ Want to try the new features in v12.0? Just head over to the demo site: [https:/
 
 ## Release Notes
 
-See the full release notes at [https://inveniordm.docs.cern.ch/releases/versions/version-v12.0.0/](https://inveniordm.docs.cern.ch/releases/versions/version-v12.0.0/) and the upgrade guide at [https://inveniordm.docs.cern.ch/releases/upgrading/upgrade-v12.0/](https://inveniordm.docs.cern.ch/releases/upgrading/upgrade-v12.0/).
+See the full release notes at [https://inveniordm.docs.cern.ch/releases/v12/version-v12.0.0/](https://inveniordm.docs.cern.ch/releases/v12/version-v12.0.0/) and the upgrade guide at [https://inveniordm.docs.cern.ch/releases/v12/upgrade-v12.0/](https://inveniordm.docs.cern.ch/releases/v12/upgrade-v12.0/).
 
 ## What’s new?
 
@@ -80,7 +80,7 @@ Another notable addition is the integration of [invenio-pages](https://github.co
 
 ## Breaking changes
 
-Make sure to read the [Breaking Changes](https://inveniordm.docs.cern.ch/releases/versions/version-v12.0.0/#breaking-changes) section in the release notes.
+Make sure to read the [Breaking Changes](https://inveniordm.docs.cern.ch/releases/v12/version-v12.0.0/#breaking-changes) section in the release notes.
 
 ## Limitations and known issues
 


### PR DESCRIPTION
### Description

> Please describe briefly your pull request.

Looks like URL structure around versions on the documentation site has changed. This commit replaces /versions/ in some URLs with either /v12/ or /v11/.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.